### PR TITLE
Open sheet embeds in a split pane

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ import { ExcelProSettingTab } from './settingTab'
 import {
   initializeMarkdownPostProcessor,
   markdownPostProcessor,
+  refreshEmbeddedSheet,
 } from './post-processor/markdownPostProcessor'
 import type { FontInfo } from './services/fontManager'
 import { FontManager } from './services/fontManager'
@@ -134,6 +135,13 @@ export default class ExcelProPlugin extends Plugin {
           // 更改当前表格的 name 字段
           emitEvent('fileRenamed', { oldPath, newPath: file.path })
           log('[ExcelProPlugin]', 'Send fileRenamed', oldPath, file.path)
+        }
+      }),
+    )
+    this.registerEvent(
+      this.app.vault.on('modify', async (file) => {
+        if (file instanceof TFile && this.isExcelFile(file)) {
+          await refreshEmbeddedSheet(file)
         }
       }),
     )
@@ -387,10 +395,11 @@ export default class ExcelProPlugin extends Plugin {
     if (location === 'new-tab')
       leaf = this.app.workspace.getLeaf('tab')
 
+    if (location === 'new-pane')
+      leaf = this.app.workspace.getLeaf('split')
+
     if (!leaf) {
       leaf = this.app.workspace.getLeaf(false)
-      if (leaf.view.getViewType() !== 'empty' && location === 'new-pane')
-        leaf = this.app.workspace.getMostRecentLeaf()
     }
 
     leaf

--- a/src/post-processor/markdownPostProcessor.ts
+++ b/src/post-processor/markdownPostProcessor.ts
@@ -14,10 +14,49 @@ let plugin: ExcelProPlugin
 let vault: Vault
 let metadataCache: MetadataCache
 
+interface RenderedEmbed {
+  el: HTMLDivElement
+  src: string
+  alt: string
+  file: TFile
+}
+
+const renderedEmbeds = new Map<string, Set<RenderedEmbed>>()
+
 export function initializeMarkdownPostProcessor(p: ExcelProPlugin) {
   plugin = p
   vault = p.app.vault
   metadataCache = p.app.metadataCache
+}
+
+export async function refreshEmbeddedSheet(file: TFile) {
+  const renders = renderedEmbeds.get(file.path)
+  if (!renders?.size)
+    return
+
+  const data = await vault.read(file)
+  const existing = Array.from(renders)
+  for (const render of existing) {
+    renders.delete(render)
+    if (!render.el.isConnected)
+      continue
+
+    const next = await createEmbedLinkDiv(render.src, render.alt, file, data)
+    render.el.replaceWith(next)
+  }
+
+  if (renders.size === 0)
+    renderedEmbeds.delete(file.path)
+}
+
+function trackRenderedEmbed(file: TFile, el: HTMLDivElement, src: string, alt: string) {
+  let renders = renderedEmbeds.get(file.path)
+  if (!renders) {
+    renders = new Set<RenderedEmbed>()
+    renderedEmbeds.set(file.path, renders)
+  }
+
+  renders.add({ el, src, alt, file })
 }
 
 /**
@@ -212,6 +251,7 @@ async function createEmbedLinkDiv(src: string, alt: string, file: TFile, data: s
   }
 
   const embedLinkDiv = createDiv()
+  trackRenderedEmbed(file, embedLinkDiv, src, alt)
 
   if (plugin.settings.showSheetButton === 'true') {
     const fileEmbed = embedLinkDiv.createDiv({


### PR DESCRIPTION
﻿## Summary
- open sheet embed buttons in a split pane so the embedded table stays visible while editing
- track rendered sheet embeds by source file
- refresh connected embed renderers when the source sheet file is modified

Fixes #145.

## Verification
- `git diff --check`
- Parser-only TypeScript pass was attempted with `npx -p typescript@5.9.3 tsc --noEmit --skipLibCheck --noResolve ...`; it reached only expected missing dependency/Obsidian global errors because this checkout has no `node_modules` and the repo depends on git+ssh packages.

AI-assisted with OpenAI Codex.
