### PR TITLE
fix: pause rendering for hidden sheet views

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "release": "release-it",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test:render-visibility": "node --test tests/render-visibility.test.js",
     "patch-local": "node scripts/patch-local.js"
   },
   "dependencies": {

--- a/src/views/tabs/SheetTab.tsx
+++ b/src/views/tabs/SheetTab.tsx
@@ -6,6 +6,7 @@ import type { INavigationOutgoingLinkOperationParams } from '@ljcoder/sheets-out
 import { NavigationOutgoingLinkOperation } from '@ljcoder/sheets-outgoing-link-ui'
 import { ScrollToRangeOperation } from '@univerjs/sheets-ui'
 import { SetRangeValuesCommand } from '@univerjs/sheets'
+import { IRenderManagerService } from '@univerjs/engine-render'
 import { SHEET_DRAWING_PLUGIN, InsertSheetDrawingCommand, RemoveSheetDrawingCommand } from '@univerjs/sheets-drawing'
 import { Spin } from 'antd'
 import { ReplaceSnapshotCommand } from '@univerjs/docs-ui'
@@ -14,6 +15,7 @@ import { SaveCommand } from '@ljcoder/save'
 import { InsertLocalCellImageOperation, InsertLocalFloatImageOperation } from '@ljcoder/local-image'
 import { Modal, Platform, TFile } from 'obsidian'
 import { createUniver } from '../univer/setup-univer'
+import { observeRenderVisibility } from '../univer/render-visibility'
 import { useEditorContext } from '../../context/editorContext'
 import { randomString } from '../../utils/uuid'
 import { deepClone, rangeToNumber } from '../../utils/data'
@@ -173,6 +175,7 @@ export function SheetTab({ switchTab }: { switchTab: () => void }) {
   const { editor, app } = useEditorContext()
   const { plugin } = editor
   const containerRef = useRef<HTMLDivElement>(null)
+  const univerRef = useRef<ReturnType<typeof createUniver>['univer'] | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
   const [spinTip, setSpinTip] = useState<string>(t('LOADING'))
   // 保存最新的 store state，供事件回调读取，避免闭包捕获陈旧 state
@@ -196,6 +199,7 @@ export function SheetTab({ switchTab }: { switchTab: () => void }) {
 
     const mobileRenderMode = plugin.settings.mobileRenderMode
     const { univerAPI, univer } = createUniver(plugin.availableFonts, options, containerRef.current, mobileRenderMode, darkMode)
+    univerRef.current = univer
     setUniverApi(univerAPI)
 
     return () => {
@@ -210,6 +214,7 @@ export function SheetTab({ switchTab }: { switchTab: () => void }) {
           log('[SheetTab]', 'disposeUniver', univer)
           univer.dispose()
         }
+        univerRef.current = null
         containerRef.current = null
       }, 0)
     }
@@ -375,6 +380,7 @@ export function SheetTab({ switchTab }: { switchTab: () => void }) {
   useEffect(() => {
     let lifeCycleDisposable: { dispose: () => void } | null = null
     let commandExecutedDisposable: { dispose: () => void } | null = null
+    let stopObservingVisibility: (() => void) | null = null
     if (univerApi) {
       const locale = Tools.convertNumberFormatLocalToLocaleType(plugin.settings.numberFormatLocal)
       if (state.sheet) {
@@ -393,6 +399,16 @@ export function SheetTab({ switchTab }: { switchTab: () => void }) {
 
       lifeCycleDisposable = univerApi.addEvent(univerApi.Event.LifeCycleChanged, (res) => {
         if (res.stage === LifecycleStages.Rendered) {
+          // Obsidian keeps background tabs mounted, so Univer must pause its render loop explicitly.
+          if (!stopObservingVisibility && containerRef.current && univerRef.current) {
+            const workbookId = univerApi.getActiveWorkbook()?.getId()
+            const render = workbookId
+              ? univerRef.current.__getInjector().get(IRenderManagerService).getRenderUnitById(workbookId)
+              : null
+            if (render) {
+              stopObservingVisibility = observeRenderVisibility(render, containerRef.current)
+            }
+          }
           setLoading(false)
           switchTab()
         }
@@ -539,8 +555,10 @@ export function SheetTab({ switchTab }: { switchTab: () => void }) {
       log('[SheetTab]', 'univerAPi卸载监听', lifeCycleDisposable, commandExecutedDisposable)
       lifeCycleDisposable?.dispose()
       commandExecutedDisposable?.dispose()
+      stopObservingVisibility?.()
       lifeCycleDisposable = null
       commandExecutedDisposable = null
+      stopObservingVisibility = null
     }
   }, [univerApi])
 

--- a/src/views/univer/render-visibility.d.ts
+++ b/src/views/univer/render-visibility.d.ts
@@ -1,0 +1,9 @@
+interface RenderVisibilityController {
+  activate: () => void
+  deactivate: () => void
+}
+
+export function observeRenderVisibility(
+  render: RenderVisibilityController,
+  container: Element,
+): () => void

--- a/src/views/univer/render-visibility.js
+++ b/src/views/univer/render-visibility.js
@@ -1,0 +1,26 @@
+/**
+ * @param {{ activate: () => void, deactivate: () => void }} render
+ * @param {Element} container
+ * @returns {() => void}
+ */
+export function observeRenderVisibility(render, container) {
+  const Observer = container.ownerDocument.defaultView?.IntersectionObserver
+  if (!Observer) {
+    return () => {}
+  }
+
+  const observer = new Observer((entries) => {
+    const entry = entries.find(item => item.target === container)
+    if (!entry) {
+      return
+    }
+    if (entry.isIntersecting) {
+      render.activate()
+    }
+    else {
+      render.deactivate()
+    }
+  })
+  observer.observe(container)
+  return () => observer.disconnect()
+}

--- a/tests/render-visibility.test.js
+++ b/tests/render-visibility.test.js
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { observeRenderVisibility } from '../src/views/univer/render-visibility.js'
+
+test('uses the container realm and follows visibility until disconnected', () => {
+  let callback
+  let disconnected = false
+  const calls = []
+  const container = {
+    ownerDocument: {
+      defaultView: {
+        IntersectionObserver: class {
+          constructor(cb) {
+            callback = cb
+          }
+
+          observe() {}
+          disconnect() { disconnected = true }
+        },
+      },
+    },
+  }
+
+  const stop = observeRenderVisibility({
+    activate: () => calls.push('activate'),
+    deactivate: () => calls.push('deactivate'),
+  }, container)
+
+  callback([{ target: container, isIntersecting: false }])
+  callback([{ target: container, isIntersecting: true }])
+  stop()
+
+  assert.deepEqual(calls, ['deactivate', 'activate'])
+  assert.equal(disconnected, true)
+})
+
+test('keeps the render active when the container realm has no observer', () => {
+  const calls = []
+  const stop = observeRenderVisibility({
+    activate: () => calls.push('activate'),
+    deactivate: () => calls.push('deactivate'),
+  }, { ownerDocument: { defaultView: {} } })
+
+  stop()
+  assert.deepEqual(calls, [])
+})


### PR DESCRIPTION
## Summary

- observe the Sheet Plus render container in its owning window, including Obsidian popout windows
- call Univer RenderUnit `deactivate()` while the workbook view is hidden and `activate()` when it becomes visible again
- keep workbook state and edit/save subscriptions alive instead of disposing and rebuilding Univer
- add a dependency-free Node 20-compatible regression check for visibility transitions, cleanup, popout realm selection, and the no-Observer fallback

Fixes #162.

## Why

Obsidian keeps inactive tabs mounted. `SheetTab` previously disposed Univer only when React unmounted, so a hidden workbook left its RenderUnit active. Univer 0.25 maps the RenderUnit activation state to `engine.runRenderLoop(frameFn)` / `engine.stopRenderLoop(frameFn)`.

The fresh three-state comparison in #162 shows residual Renderer CPU activity while the workbook is hidden and none after the view is closed. The historical 16.4 GB Renderer incident motivated this investigation, but this PR intentionally does not claim that background rendering alone caused that memory footprint.

## Validation

- `npm run test:render-visibility` - 2 tests passed
- `npx -y node@20 --test tests/render-visibility.test.js` - 2 tests passed on Node 20
- `node --check src/views/univer/render-visibility.js`
- `node --check tests/render-visibility.test.js`
- TypeScript 5.9 `checkJs` validation passed for the helper
- esbuild parsed and bundled `SheetTab.tsx` with external dependencies
- `git diff --check`

The repository cannot currently run a clean full build from this standalone clone:

- `pnpm install --frozen-lockfile` fails because `pnpm-lock.yaml` is absent
- `pnpm install --no-frozen-lockfile` fails because the published repository has no catalog entry for `@univerjs/vite-plugin`

No dependency/workspace metadata was changed to hide that existing repository limitation.
