### PR TITLE
perf: pause idle Sheet render loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test:render-visibility": "node --test tests/render-visibility.test.js",
+    "patch-built-render-idle": "node scripts/patch-built-render-idle.mjs",
     "patch-local": "node scripts/patch-local.js"
   },
   "dependencies": {

--- a/scripts/patch-built-render-idle.mjs
+++ b/scripts/patch-built-render-idle.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+
+const file = process.argv[2]
+if (!file) {
+  console.error('usage: node scripts/patch-built-render-idle.mjs <main.js>')
+  process.exit(1)
+}
+
+const source = fs.readFileSync(file, 'utf8')
+const pattern = /function FYi\(t,e\)\{const n=e\.ownerDocument\.defaultView\?\.IntersectionObserver;if\(!n\)return\(\)=>\{\};const r=new n\(i=>\{const a=i\.find\(o=>o\.target===e\);a&&\(a\.isIntersecting\?t\.activate\(\):t\.deactivate\(\)\)\}\);return r\.observe\(e\),\(\)=>r\.disconnect\(\)\}/
+const replacement = 'function FYi(t,e){const n=e.ownerDocument.defaultView?.IntersectionObserver;if(!n)return()=>{};const r=e.ownerDocument.defaultView;let i=null,a=!1;const o=()=>{i!==null&&(clearTimeout(i),i=null)},s=()=>{o(),t.deactivate()},l=()=>{if(!a)return;t.activate(),o(),i=setTimeout(s,2e3)},c=new n(d=>{const f=d.find(u=>u.target===e);f&&(a=f.isIntersecting,a?l():s())});c.observe(e);const u=["pointerdown","pointermove","keydown","wheel","touchstart"];return u.forEach(d=>e.addEventListener?.(d,l,{passive:!0})),r?.addEventListener?.("blur",s),r?.addEventListener?.("focus",l),i=setTimeout(s,2e3),()=>{c.disconnect(),u.forEach(d=>e.removeEventListener?.(d,l)),r?.removeEventListener?.("blur",s),r?.removeEventListener?.("focus",l),o()}}'
+
+if (!pattern.test(source)) {
+  console.error('expected unpatched FYi function exactly once')
+  process.exit(1)
+}
+const patched = source.replace(pattern, replacement)
+fs.writeFileSync(file, patched)
+console.log(`patched ${file}`)

--- a/src/views/univer/render-visibility.d.ts
+++ b/src/views/univer/render-visibility.d.ts
@@ -6,4 +6,5 @@ interface RenderVisibilityController {
 export function observeRenderVisibility(
   render: RenderVisibilityController,
   container: Element,
+  idleMs?: number,
 ): () => void

--- a/src/views/univer/render-visibility.js
+++ b/src/views/univer/render-visibility.js
@@ -1,12 +1,35 @@
 /**
  * @param {{ activate: () => void, deactivate: () => void }} render
  * @param {Element} container
+ * @param {number} [idleMs=2000] Pause the render loop after this much inactivity.
  * @returns {() => void}
  */
-export function observeRenderVisibility(render, container) {
+export function observeRenderVisibility(render, container, idleMs = 2000) {
   const Observer = container.ownerDocument.defaultView?.IntersectionObserver
   if (!Observer) {
     return () => {}
+  }
+
+  const win = container.ownerDocument.defaultView
+  let visible = false
+  let idleTimer = null
+  const clearIdle = () => {
+    if (idleTimer !== null) {
+      clearTimeout(idleTimer)
+      idleTimer = null
+    }
+  }
+  const pause = () => {
+    clearIdle()
+    render.deactivate()
+  }
+  const wake = () => {
+    if (!visible) {
+      return
+    }
+    render.activate()
+    clearIdle()
+    idleTimer = setTimeout(pause, idleMs)
   }
 
   const observer = new Observer((entries) => {
@@ -14,13 +37,27 @@ export function observeRenderVisibility(render, container) {
     if (!entry) {
       return
     }
+    visible = entry.isIntersecting
     if (entry.isIntersecting) {
-      render.activate()
+      wake()
     }
     else {
-      render.deactivate()
+      pause()
     }
   })
   observer.observe(container)
-  return () => observer.disconnect()
+
+  const activityEvents = ['pointerdown', 'pointermove', 'keydown', 'wheel', 'touchstart']
+  activityEvents.forEach(type => container.addEventListener?.(type, wake, { passive: true }))
+  win?.addEventListener?.('blur', pause)
+  win?.addEventListener?.('focus', wake)
+  idleTimer = setTimeout(pause, idleMs)
+
+  return () => {
+    observer.disconnect()
+    activityEvents.forEach(type => container.removeEventListener?.(type, wake))
+    win?.removeEventListener?.('blur', pause)
+    win?.removeEventListener?.('focus', wake)
+    clearIdle()
+  }
 }

--- a/tests/render-visibility.test.js
+++ b/tests/render-visibility.test.js
@@ -44,3 +44,53 @@ test('keeps the render active when the container realm has no observer', () => {
   stop()
   assert.deepEqual(calls, [])
 })
+
+test('pauses after inactivity and wakes on container activity', async () => {
+  let callback
+  const listeners = new Map()
+  const container = {
+    ownerDocument: { defaultView: { IntersectionObserver: class {
+      constructor(cb) { callback = cb }
+      observe() {}
+      disconnect() {}
+    } } },
+    addEventListener(type, listener) { listeners.set(type, listener) },
+    removeEventListener() {},
+  }
+  const calls = []
+  const stop = observeRenderVisibility({
+    activate: () => calls.push('activate'),
+    deactivate: () => calls.push('deactivate'),
+  }, container, 5)
+
+  callback([{ target: container, isIntersecting: true }])
+  await new Promise(resolve => setTimeout(resolve, 10))
+  assert.equal(calls.at(-1), 'deactivate')
+  listeners.get('pointerdown')()
+  assert.equal(calls.at(-1), 'activate')
+  stop()
+})
+
+test('does not wake a hidden render when the window gains focus', () => {
+  let callback
+  const windowListeners = new Map()
+  const container = {
+    ownerDocument: { defaultView: { IntersectionObserver: class {
+      constructor(cb) { callback = cb }
+      observe() {}
+      disconnect() {}
+    }, addEventListener(type, listener) { windowListeners.set(type, listener) }, removeEventListener() {} } },
+    addEventListener() {},
+    removeEventListener() {},
+  }
+  const calls = []
+  const stop = observeRenderVisibility({
+    activate: () => calls.push('activate'),
+    deactivate: () => calls.push('deactivate'),
+  }, container, 50)
+
+  callback([{ target: container, isIntersecting: false }])
+  windowListeners.get('focus')()
+  assert.deepEqual(calls, ['deactivate'])
+  stop()
+})


### PR DESCRIPTION
## Summary

- pause the Univer RenderUnit after two seconds without Sheet interaction
- wake it on pointer, keyboard, wheel, or touch activity
- prevent window focus from waking hidden Sheet containers
- clean up timers, listeners, and the IntersectionObserver on disposal
- add dependency-free regression coverage for idle pause, activity wake, and hidden focus

Fixes #164.

## Why

The previous fix addressed hidden Obsidian tabs, but an active Sheet still kept its render loop running indefinitely while idle. On a real 1.5 MB workbook, the local Renderer rose from about 1.85 GB RSS to 5.33 GB in roughly 25 seconds, with CPU reaching about 66%.

After this patch was loaded into the local plugin bundle and Obsidian was restarted, the same real workbook stayed around 0.90–0.97 GB RSS for more than 30 seconds at roughly 8–12% CPU. No vault content was changed.

This PR is a mitigation for continuous idle rendering. It does not claim that the historical 16 GB incident had only one root cause.

## Validation

- `node --test tests/render-visibility.test.js` — 4 tests passed
- `node --check src/views/univer/render-visibility.js`
- `node --check scripts/patch-built-render-idle.mjs`
- `node --check` on the locally patched `main.js`
- `git diff --check`
- independent read-only review: PASS

The standalone upstream clone still cannot run a full Vite build because the published repository has no catalog entry for `@univerjs/vite-plugin`; the source patch and local bundle patch were both syntax-checked.
